### PR TITLE
adding prosconductor and prosconductor.providers to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ install_reqs = [str(r.req) for r in parse_requirements('requirements.txt', sessi
 setup(
     name='pros-cli',
     version='2.beta',
-    packages=['prosflasher', 'proscli', 'prosconfig'],
+    packages=['prosflasher', 'proscli', 'prosconfig', 'prosconductor', 'prosconductor.providers'],
     url='https://github.com/purduesigbots/pros-cli',
     license='',
     author='Purdue ACM Sigbots',


### PR DESCRIPTION
Hi Elliot,  The setup.py seems to be missing the prosconductor and prosconductor.providers packages which I needed to successfully install the python cli.

Hope this is helpful.

Rock on,

pete
