### PR TITLE
Fix first-run

### DIFF
--- a/proscli/conductor.py
+++ b/proscli/conductor.py
@@ -19,14 +19,14 @@ def first_run(ctx: proscli.utils.State, force: bool = False, defaults: bool = Fa
     if len(utils.get_depot_configs(ctx.pros_cfg)) == 0:
         click.echo('You don\'t currently have any depots configured.')
     if len(utils.get_depot_configs(ctx.pros_cfg)) == 0 or force:
-        if click.confirm('Add the official PROS kernel depot, pros-mainline?', default=True) or defaults:
+        if defaults or click.confirm('Add the official PROS kernel depot, pros-mainline?', default=True):
             click.get_current_context().invoke(add_depot, name='pros-mainline',
                                                registrar='github-releases',
                                                location='purduesigbots/pros',
                                                configure=False)
             click.echo('Added pros-mainline to available depots. '
                        'Add more depots in the future by running `pros conduct add-depot`\n')
-            if click.confirm('Download the latest kernel?', default=True) or defaults:
+            if defaults or click.confirm('Download the latest kernel?', default=True):
                 click.get_current_context().invoke(download, name='kernel', depot='pros-mainline')
 
 

--- a/proscli/main.py
+++ b/proscli/main.py
@@ -26,7 +26,7 @@ def help_cmd(ctx):
                cls=click.CommandCollection,
                context_settings=dict(help_option_names=['-h', '--help']),
                sources=[proscli.terminal_cli, proscli.build_cli, proscli.flasher_cli, proscli.conductor_cli])
-@click.version_option(version='2.1.920', prog_name='pros')
+@click.version_option(version='2.1.923', prog_name='pros')
 @default_options
 def cli():
     pass


### PR DESCRIPTION
`pros conduct first-run --use-defaults` did not automatically use defaults since the or short-circuiting was implemented backwards.
