### PR TITLE
Ignore UTF-8 errors in serial terminal

### DIFF
--- a/proscli/serial_terminal.py
+++ b/proscli/serial_terminal.py
@@ -193,7 +193,7 @@ class Terminal(object):
                     if self.output_raw:
                         self.console.write_bytes(data)
                     else:
-                        text = data.decode('utf-8')
+                        text = data.decode('utf-8', 'ignore')
                         for transformation in self.transformations:
                             text = transformation(text)
                         self.console.write(text)


### PR DESCRIPTION
Currently whenever the serial terminal encounters invalid UTF-8 bytes it errors:

```
NOTE: This is an early prototype of the terminal. Nothing is guaranteed to work.

Powered by PROS 2.11.0

PROS (C)2011-2014 Purdue ACM SIGBOTS
This program has ABSOLUTELY NO WARRANTY, not even an implied
warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

HException in thread serial-rx-term:
Traceback (most recent call last):
  File "/usr/lib/python3.5/threading.py", line 914, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.5/threading.py", line 862, in run
    self._target(*self._args, **self._kwargs)
  File "/usr/local/lib/python3.5/dist-packages/proscli/serial_terminal.py", line 196, in reader
    text = data.decode('utf-8')
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xad in position 6: invalid start byte

^C
Aborted!
```

This commit fixes that annoying issue
