### PR TITLE
Exit with a code and handle SIGINT in spawned threads

### DIFF
--- a/build.py
+++ b/build.py
@@ -28,7 +28,7 @@ else:
 
 setup(
     name='pros-cli',
-    version='2.0',
+    version='2.1.6',
     packages=modules,
     url='https://github.com/purduesigbots/pros-cli',
     license='',
@@ -106,4 +106,3 @@ setup(
 #         scripts=[Executable('proscli/main.py')]
 #     )
 # else:
-

--- a/proscli/build.py
+++ b/proscli/build.py
@@ -22,7 +22,6 @@ def make(ctx, build_args):
     If on Windows, will invoke make located in on the PROS_TOOLCHAIN.
 
     Also has the added benefit of looking for the config.pros file"""
-    click.echo('Invoking make {}...'.format(' '.join(build_args)))
     cfg = prosconfig.ProjectConfig(prosconfig.ProjectConfig.find_project('.'))
     cwd = '.'
     if cfg is not None:
@@ -33,7 +32,8 @@ def make(ctx, build_args):
         cmd = os.path.join(os.environ.get('PROS_TOOLCHAIN'), 'bin', 'make.exe')
     else:
         cmd = 'make'
-    build_args = ['make'] + list(build_args)['make'].append(build_args)
+    build_args = ['make'] + list(build_args)
+    click.echo('Invoking {} in {}...'.format(' '.join(build_args), cwd))
     p = subprocess.Popen(executable=cmd, args=build_args, cwd=cwd, env=env,
                          stdout=sys.stdout, stderr=sys.stderr)
     p.wait()

--- a/proscli/build.py
+++ b/proscli/build.py
@@ -22,17 +22,18 @@ def make(ctx, build_args):
     If on Windows, will invoke make located in on the PROS_TOOLCHAIN.
 
     Also has the added benefit of looking for the config.pros file"""
-    cfg = prosconfig.ProjectConfig(prosconfig.ProjectConfig.find_project('.'))
-    cwd = '.'
-    if cfg is not None:
+    try:
+        cfg = prosconfig.ProjectConfig(prosconfig.ProjectConfig.find_project('.'))
         cwd = cfg.directory
+    except prosconfig.ConfigNotFoundException:
+        cwd = '.'
     env = os.environ.copy()
     if os.name == 'nt':
         env['PATH'] += ';' + os.path.join(os.environ.get('PROS_TOOLCHAIN'), 'bin')
         cmd = os.path.join(os.environ.get('PROS_TOOLCHAIN'), 'bin', 'make.exe')
     else:
         cmd = 'make'
-    build_args = ['make'] + list(build_args)
+    build_args = ['make'] + list(build_args)  # prepend 'make' because of magic
     click.echo('Invoking {} in {}...'.format(' '.join(build_args), cwd))
     p = subprocess.Popen(executable=cmd, args=build_args, cwd=cwd, env=env,
                          stdout=sys.stdout, stderr=sys.stderr)

--- a/proscli/build.py
+++ b/proscli/build.py
@@ -5,6 +5,7 @@ import os
 # import prosconfig
 import proscli.flasher
 import proscli.terminal
+import prosconfig
 
 
 @click.group()
@@ -22,10 +23,10 @@ def make(ctx, build_args):
 
     Also has the added benefit of looking for the config.pros file"""
     click.echo('Invoking make {}...'.format(' '.join(build_args)))
-    # cfg = prosconfig.find_project('.')
+    cfg = prosconfig.ProjectConfig.find_project('.')
     cwd = '.'
-    # if cfg is not None:
-    #     cwd = cfg.path
+    if cfg is not None:
+        cwd = cfg.path
     env = os.environ.copy()
     if os.name == 'nt':
         env['PATH'] += ';' + os.path.join(os.environ.get('PROS_TOOLCHAIN'), 'bin')

--- a/proscli/build.py
+++ b/proscli/build.py
@@ -23,16 +23,17 @@ def make(ctx, build_args):
 
     Also has the added benefit of looking for the config.pros file"""
     click.echo('Invoking make {}...'.format(' '.join(build_args)))
-    cfg = prosconfig.ProjectConfig.find_project('.')
+    cfg = prosconfig.ProjectConfig(prosconfig.ProjectConfig.find_project('.'))
     cwd = '.'
     if cfg is not None:
-        cwd = cfg.path
+        cwd = cfg.directory
     env = os.environ.copy()
     if os.name == 'nt':
         env['PATH'] += ';' + os.path.join(os.environ.get('PROS_TOOLCHAIN'), 'bin')
         cmd = os.path.join(os.environ.get('PROS_TOOLCHAIN'), 'bin', 'make.exe')
     else:
         cmd = 'make'
+    build_args = ['make'] + list(build_args)['make'].append(build_args)
     p = subprocess.Popen(executable=cmd, args=build_args, cwd=cwd, env=env,
                          stdout=sys.stdout, stderr=sys.stderr)
     p.wait()

--- a/proscli/build.py
+++ b/proscli/build.py
@@ -4,6 +4,7 @@ import sys
 import os
 # import prosconfig
 import proscli.flasher
+import proscli.terminal
 
 
 @click.group()
@@ -28,7 +29,9 @@ def make(ctx, build_args):
     env = os.environ.copy()
     if os.name == 'nt':
         env['PATH'] += ';' + os.path.join(os.environ.get('PROS_TOOLCHAIN'), 'bin')
-    cmd = 'make'
+        cmd = os.path.join(os.environ.get('PROS_TOOLCHAIN'), 'bin', 'make.exe')
+    else:
+        cmd = 'make'
     p = subprocess.Popen(executable=cmd, args=build_args, cwd=cwd, env=env,
                          stdout=sys.stdout, stderr=sys.stderr)
     p.wait()
@@ -42,3 +45,12 @@ def make(ctx, build_args):
 def make_flash(ctx, build_args):
     ctx.invoke(make, build_args=build_args)
     ctx.invoke(proscli.flasher.flash)
+
+
+@build_cli.command(name='mut', help='Combines \'make\', \'flash\', and \'terminal\'')
+@click.argument('build-args', nargs=-1)
+@click.pass_context
+def make_flash_terminal(ctx, build_args):
+    ctx.invoke(make, build_args=build_args)
+    ctx.invoke(proscli.flasher.flash)
+    ctx.invoke(proscli.terminal.terminal)

--- a/proscli/flasher.py
+++ b/proscli/flasher.py
@@ -164,8 +164,8 @@ def lsusb(cfg):
         click.echo(prosflasher.ports.create_port_list(cfg.verbosity > 0))
 
 
-@flasher_cli.command(name='dump-cortex', short_help='Dumps user flash contents to a specified file')
-@click.option('-v', '--verbose', is_flag=True)
-@click.argument('file', default=sys.stdout, type=click.File())
-def dump_cortex(file, verbose):
-    pass
+# @flasher_cli.command(name='dump-cortex', short_help='Dumps user flash contents to a specified file')
+# @click.option('-v', '--verbose', is_flag=True)
+# @click.argument('file', default=sys.stdout, type=click.File())
+# def dump_cortex(file, verbose):
+#     pass

--- a/proscli/main.py
+++ b/proscli/main.py
@@ -17,7 +17,7 @@ def main():
                cls=click.CommandCollection,
                context_settings=dict(help_option_names=['-h', '--help']),
                sources=[proscli.terminal_cli, proscli.build_cli, proscli.flasher_cli, proscli.conductor_cli])
-@click.version_option(version='2.1.5', prog_name='pros')
+@click.version_option(version='2.1.6', prog_name='pros')
 @default_options
 def cli():
     pass

--- a/proscli/serial_terminal.py
+++ b/proscli/serial_terminal.py
@@ -250,6 +250,7 @@ class Terminal(object):
             self.receiver_thread.join()
 
     def stop(self):
+        print('Stopping terminal!')
         self.alive = False
         self._stop_rx()
         self._stop_tx()

--- a/proscli/serial_terminal.py
+++ b/proscli/serial_terminal.py
@@ -4,6 +4,7 @@ from proscli.utils import debug
 import serial
 import signal
 import sys
+import time
 import threading
 
 # This file is a modification of the miniterm implementation on pyserial

--- a/proscli/terminal.py
+++ b/proscli/terminal.py
@@ -1,7 +1,9 @@
 import click
 import proscli.serial_terminal
 import prosflasher.ports
+import signal
 import sys
+import time
 
 
 @click.group()
@@ -12,7 +14,8 @@ def terminal_cli():
 @terminal_cli.command(short_help='Open terminal with the microcontroller')
 @click.argument('port', default='default')
 def terminal(port):
-    click.echo(click.style('NOTE: This is an early prototype of the terminal. Nothing is guaranteed to work.',
+    click.echo(click.style('NOTE: This is an early prototype of the terminal.'
+                           ' Nothing is guaranteed to work.',
                            blink=True, bold=True))
     if port == 'default':
         if len(prosflasher.ports.list_com_ports()) == 1:
@@ -21,7 +24,9 @@ def terminal(port):
             click.echo('Multiple ports were found:')
             click.echo(prosflasher.ports.create_port_list())
             port = click.prompt('Select a port to open',
-                                type=click.Choice([p.device for p in prosflasher.ports.list_com_ports()]))
+                                type=click.Choice([p.device for p in
+                                                  prosflasher.
+                                                  ports.list_com_ports()]))
         else:
             click.echo('No ports were found.')
             click.get_current_context().abort()
@@ -29,11 +34,16 @@ def terminal(port):
 
     ser = prosflasher.ports.create_serial(port)
     term = proscli.serial_terminal.Terminal(ser)
+    signal.signal(signal.SIGINT, term.stop)
     term.start()
-    while(term.alive):
-        pass
+    try:
+        while(term.alive):
+            pass
+    except KeyboardInterrupt as e:
+        term.stop()
     term.join()
     ser.close()
+    print('Exited successfully')
     sys.exit(0)
     # term = serial.tools.miniterm.Miniterm(ser, echo=click.echo)
     # term.set_rx_encoding('UTF-8')

--- a/proscli/terminal.py
+++ b/proscli/terminal.py
@@ -34,6 +34,7 @@ def terminal(port):
         pass
     term.join()
     ser.close()
+    sys.exit(0)
     # term = serial.tools.miniterm.Miniterm(ser, echo=click.echo)
     # term.set_rx_encoding('UTF-8')
     # term.set_tx_encoding('UTF-8')

--- a/proscli/terminal.py
+++ b/proscli/terminal.py
@@ -32,15 +32,13 @@ def terminal(port):
             click.get_current_context().abort()
             sys.exit()
 
+    # signal.signal(signal.SIGINT, signal_handler)
     ser = prosflasher.ports.create_serial(port)
     term = proscli.serial_terminal.Terminal(ser)
     signal.signal(signal.SIGINT, term.stop)
     term.start()
-    try:
-        while(term.alive):
-            pass
-    except KeyboardInterrupt as e:
-        term.stop()
+    while term.alive:
+        time.sleep(0.005)
     term.join()
     ser.close()
     print('Exited successfully')

--- a/proscli/terminal.py
+++ b/proscli/terminal.py
@@ -15,8 +15,7 @@ def terminal_cli():
 @click.argument('port', default='default')
 def terminal(port):
     click.echo(click.style('NOTE: This is an early prototype of the terminal.'
-                           ' Nothing is guaranteed to work.',
-                           blink=True, bold=True))
+                           ' Nothing is guaranteed to work.', bold=True))
     if port == 'default':
         if len(prosflasher.ports.list_com_ports()) == 1:
             port = prosflasher.ports.list_com_ports()[0].device
@@ -24,15 +23,11 @@ def terminal(port):
             click.echo('Multiple ports were found:')
             click.echo(prosflasher.ports.create_port_list())
             port = click.prompt('Select a port to open',
-                                type=click.Choice([p.device for p in
-                                                  prosflasher.
-                                                  ports.list_com_ports()]))
+                                type=click.Choice([p.device for p in prosflasher.ports.list_com_ports()]))
         else:
             click.echo('No ports were found.')
             click.get_current_context().abort()
             sys.exit()
-
-    # signal.signal(signal.SIGINT, signal_handler)
     ser = prosflasher.ports.create_serial(port)
     term = proscli.serial_terminal.Terminal(ser)
     signal.signal(signal.SIGINT, term.stop)
@@ -43,15 +38,3 @@ def terminal(port):
     ser.close()
     print('Exited successfully')
     sys.exit(0)
-    # term = serial.tools.miniterm.Miniterm(ser, echo=click.echo)
-    # term.set_rx_encoding('UTF-8')
-    # term.set_tx_encoding('UTF-8')
-    # term.exit_character = '\x03'
-    # try:
-    #     term.start()
-    #     term.join()
-    # except KeyboardInterrupt:
-    #     pass
-    # except serial.serialutil.SerialException:
-    #     click.echo('Disconnected from microcontroller')
-    # term.close()

--- a/prosconductor/providers/utils.py
+++ b/prosconductor/providers/utils.py
@@ -1,5 +1,6 @@
 from functools import lru_cache
 import importlib.util
+import importlib.abc
 import os
 import re
 from prosconductor.providers import DepotProvider, DepotConfig, TemplateTypes, Identifier, TemplateDescriptor
@@ -13,11 +14,8 @@ def get_all_provider_types(pros_cfg=None):
         pros_cfg = CliConfig()
 
     for provider_file in pros_cfg.providers:
-        importlib.import_module('prosconductor.providers.{}'.format(os.path.basename(provider_file).split('.')[0]), os.path.dirname(provider_file))
-        # spec.loader.exec_module(mod)
-        # spec = importlib.util.spec_from_file_location('module.name', provider_file)
-        # mod = importlib.util.module_from_spec(spec)
-        # spec.loader.exec_module(mod)
+        spec = importlib.util.spec_from_file_location('prosconductor.providers.{}'.format(os.path.basename(provider_file).split('.')[0]), provider_file)
+        spec.loader.load_module()
 
     return {x.registrar: x for x in DepotProvider.__subclasses__()}
 

--- a/prosconductor/providers/utils.py
+++ b/prosconductor/providers/utils.py
@@ -13,9 +13,11 @@ def get_all_provider_types(pros_cfg=None):
         pros_cfg = CliConfig()
 
     for provider_file in pros_cfg.providers:
-        spec = importlib.util.spec_from_file_location('module.name', provider_file)
-        mod = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(mod)
+        importlib.import_module('prosconductor.providers.{}'.format(os.path.basename(provider_file).split('.')[0]), os.path.dirname(provider_file))
+        # spec.loader.exec_module(mod)
+        # spec = importlib.util.spec_from_file_location('module.name', provider_file)
+        # mod = importlib.util.module_from_spec(spec)
+        # spec.loader.exec_module(mod)
 
     return {x.registrar: x for x in DepotProvider.__subclasses__()}
 

--- a/prosconfig/__init__.py
+++ b/prosconfig/__init__.py
@@ -70,7 +70,7 @@ class Config(object):
 
 class ProjectConfig(Config):
     def __init__(self, path: str='.', create: bool=False, raise_on_error: bool=True):
-        file = ProjectConfig.find_project(path)
+        file = ProjectConfig.find_project(path or '.')
         if file is None and create:
             file = os.path.join(path, 'project.pros')
         elif file is None and raise_on_error:
@@ -83,11 +83,12 @@ class ProjectConfig(Config):
 
     @staticmethod
     def find_project(path):
+        path = os.path.abspath(path)
         if os.path.isfile(path):
             return path
         elif os.path.isdir(path):
             for n in range(10):
-                if os.path.isdir(path):
+                if path is not None and os.path.isdir(path):
                     files = [f for f in os.listdir(path)
                              if os.path.isfile(os.path.join(path, f)) and f.lower() == 'project.pros']
                     if len(files) == 1:  # found a project.pros file!

--- a/prosflasher/ports.py
+++ b/prosflasher/ports.py
@@ -1,3 +1,4 @@
+import click
 import serial
 import serial.tools.list_ports
 
@@ -26,7 +27,8 @@ def create_serial(port):
     if isinstance(port, str):
         try:
             port = serial.Serial(port)
-        except serial.SerialException:
+        except serial.SerialException as e:
+            click.echo('WARNING: {}'.format(e))
             port = serial.Serial()
     elif not isinstance(port, serial.Serial):
         port = serial.Serial()

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,12 @@
-from distutils.core import setup
-
+# from distutils.core import setup
+from setuptools import setup
 # setup.py for non-frozen builds
 from pip.req import parse_requirements
 install_reqs = [str(r.req) for r in parse_requirements('requirements.txt', session=False)]
 
 setup(
     name='pros-cli',
-    version='2.1.5',
+    version='2.1.6',
     packages=['prosflasher', 'proscli', 'prosconfig', 'prosconductor', 'prosconductor.providers'],
     url='https://github.com/purduesigbots/pros-cli',
     license='MPL-2.0',


### PR DESCRIPTION
Necessary to allow proper use of the atom-based terminal view.

To test:
1. Connect Cortex
2. Use `PROS:Open-Cortex` in atom
3. Click the cancel button on the terminal

If the process exits correctly, output in the terminal should cease and you should be able to open the cortex on the same COM port you used originally (previously, the process would not terminate correctly and was holding the port open until the computer restarted).
