### PR TITLE
Add upgrade CLI command

### DIFF
--- a/proscli/__init__.py
+++ b/proscli/__init__.py
@@ -5,6 +5,7 @@ from proscli.terminal import terminal_cli
 from proscli.conductor import conductor_cli
 from proscli.build import build_cli
 from proscli.flasher import flasher_cli
+from proscli.upgrade import upgrade_cli
 
 from proscli.utils import pass_state, verbosity_option
 

--- a/proscli/main.py
+++ b/proscli/main.py
@@ -16,7 +16,8 @@ def main():
 @click.command('pros',
                cls=click.CommandCollection,
                context_settings=dict(help_option_names=['-h', '--help']),
-               sources=[proscli.terminal_cli, proscli.build_cli, proscli.flasher_cli, proscli.conductor_cli])
+               sources=[proscli.terminal_cli, proscli.build_cli, proscli.flasher_cli,
+                        proscli.conductor_cli, proscli.upgrade_cli])
 @click.version_option(version='2.4.1', prog_name='pros')
 @default_options
 def cli():

--- a/proscli/upgrade.py
+++ b/proscli/upgrade.py
@@ -1,0 +1,45 @@
+import click
+from proscli.utils import default_cfg
+import os
+import os.path
+import subprocess
+import sys
+
+import json
+
+@click.group()
+def upgrade_cli():
+    pass
+
+
+def get_upgrade_command():
+    if getattr(sys, 'frozen', False):
+        cmd = os.path.abspath(os.path.join(sys.executable, '..', '..', 'updater.exe'))
+        if os.path.exists(cmd):
+            return [cmd, '/silentall', '-nofreqcheck']
+        else:
+            return False
+    else:
+        try:
+            from pip._vendor import pkg_resources
+            results = [p for p in pkg_resources.working_set if p.project_name == 'pros-cli']
+            if len(results) == 0 or not hasattr(results[0], 'location'):
+                return False
+            else:
+                return 'pip install -U -d {} pros-cli'.format(results[0].location).split(' ')
+        except Exception:
+            return False
+
+
+@upgrade_cli.command('upgrade', help='Provides a facility to run upgrade the PROS CLI')
+@default_cfg
+def upgrade(cfg):
+    cmd = get_upgrade_command()
+    if cmd is False:
+        click.echo('Could not determine installation type.')
+        sys.exit(1)
+        return
+    elif not cfg.machine_output:
+        sys.exit(subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE))
+    else:
+        click.echo(' '.join(cmd))

--- a/proscli/upgrade.py
+++ b/proscli/upgrade.py
@@ -35,7 +35,7 @@ def get_upgrade_command():
             if len(results) == 0 or not hasattr(results[0], 'location'):
                 return False
             else:
-                return ['pip', 'install', '-U', '-t', results[0].location, 'pros-cli']
+                return ['pip3', 'install', '-U', '-t', results[0].location, 'pros-cli']
         except Exception:
             return False
 

--- a/proscli/upgrade.py
+++ b/proscli/upgrade.py
@@ -26,7 +26,7 @@ def get_upgrade_command():
             if len(results) == 0 or not hasattr(results[0], 'location'):
                 return False
             else:
-                return ['pip', 'install', '-U', '-d', results[0].location, 'pros-cli']
+                return ['pip', 'install', '-U', '-t', results[0].location, 'pros-cli']
         except Exception:
             return False
 
@@ -40,7 +40,7 @@ def upgrade(cfg):
         sys.exit(1)
         return
     elif not cfg.machine_output:
-        sys.exit(subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE))
+        sys.exit(subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE).returncode
     else:
         for piece in cmd:
             click.echo(piece)

--- a/proscli/upgrade.py
+++ b/proscli/upgrade.py
@@ -26,7 +26,7 @@ def get_upgrade_command():
             if len(results) == 0 or not hasattr(results[0], 'location'):
                 return False
             else:
-                return 'pip install -U -d {} pros-cli'.format(results[0].location).split(' ')
+                return ['pip', 'install', '-U', '-d', results[0].location, 'pros-cli']
         except Exception:
             return False
 
@@ -42,4 +42,5 @@ def upgrade(cfg):
     elif not cfg.machine_output:
         sys.exit(subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE))
     else:
-        click.echo(' '.join(cmd))
+        for piece in cmd:
+            click.echo(piece)

--- a/proscli/upgrade.py
+++ b/proscli/upgrade.py
@@ -23,6 +23,13 @@ def get_upgrade_command():
         try:
             from pip._vendor import pkg_resources
             results = [p for p in pkg_resources.working_set if p.project_name == 'pros-cli']
+            if os.path.exists(os.path.join(results[0].location, '.git')):
+                if subprocess.run('where git').returncode == 0:
+                    return ['git', 'pull']
+                elif subprocess.run('where bash').returncode == 0:
+                    return ['bash', '-c', 'git pull']
+                else:
+                    return False
             if len(results) == 0 or not hasattr(results[0], 'location'):
                 return False
             else:

--- a/prosconfig/cliconfig.py
+++ b/prosconfig/cliconfig.py
@@ -16,9 +16,4 @@ class CliConfig(Config):
             self.providers = [os.path.join(os.path.dirname(sys.executable), 'githubreleases.pyc')]
         else:
             self.providers = []
-        # self.providers = [
-        #     prosconductor.providers.githubreleases.__file__
-        #         if os.path.isfile(prosconductor.providers.githubreleases.__file__) else
-        #         os.path.join(os.path.dirname(sys.executable), 'githubreleases.pyc')
-        # ]  # type: list(str)
         super(CliConfig, self).__init__(file, ctx=ctx)


### PR DESCRIPTION
CLI uses introspection to determine if the application is frozen and on Windows, and returns the appropriate upgrade.exe executable to upgrade the CLI when using Advanced Installer. When detected as installed through pip, will return the command necessary to upgrade via pip. If none of the other options are available, then will return nothing and leave it to the user to figure out how they have CLI installed (these are the two official/common ways of installing the PROS CLI)