### PR TITLE
General improvements to the flasher

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,9 @@ stage('Build') {
       }
       stage('Dependencies') {
         tool 'python3'
-        sh 'sudo apt-get install -y python3-pip'
+		if(isUnix()) {
+	        sh 'sudo apt-get install -y python3-pip'
+		}
         venv.create_virtualenv()
         venv.run 'pip3 install wheel twine'
       }

--- a/proscli/flasher.py
+++ b/proscli/flasher.py
@@ -24,13 +24,16 @@ def flasher_cli():
               help='Specifies a binary file, project directory, or project config file.')
 @click.option('-p', '--port', default='auto', metavar='PORT', help='Specifies the serial port.')
 @click.option('--no-poll', is_flag=True, default=False)
+@click.option('-r', '--retry', default=2,
+              help='Specify the number of times the flasher should retry the flash when it detects a failure'
+                   ' (default two times).')
 @default_cfg
 # @click.option('-m', '--strategy', default='cortex', metavar='STRATEGY',
 #               help='Specify the microcontroller upload strategy. Not currently used.')
-def flash(ctx, save_file_system, y, port, binary, no_poll):
+def flash(ctx, save_file_system, y, port, binary, no_poll, retry):
     """Upload binaries to the microcontroller. A serial port and binary file need to be specified.
 
-    By default, the port is automatically selected (if you want to be pendantic, 'auto').
+    By default, the port is automatically selected (if you want to be pedantic, 'auto').
     Otherwise, a system COM port descriptor needs to be used. In Windows/NT, this takes the form of COM1.
     In *nx systems, this takes the form of /dev/tty1 or /dev/acm1 or similar.
     \b
@@ -87,7 +90,7 @@ def flash(ctx, save_file_system, y, port, binary, no_poll):
 
     click.echo('Flashing ' + binary + ' to ' + ', '.join(port))
     for p in port:
-        prosflasher.upload.upload(p, binary, no_poll, ctx)
+        prosflasher.upload.upload(p, binary, no_poll, ctx, retry)
 
 
 def find_binary(path):

--- a/proscli/flasher.py
+++ b/proscli/flasher.py
@@ -92,10 +92,10 @@ def flash(ctx, save_file_system, y, port, binary, no_poll, retry):
     for p in port:
         tries = 1
         while tries <= retry:
-            click.echo('Retrying...')
             code = prosflasher.upload.upload(p, y, binary, no_poll, ctx)
             if code or code == -1000:
                 break
+            click.echo('Retrying...')
             tries += 1
 
 

--- a/proscli/flasher.py
+++ b/proscli/flasher.py
@@ -96,6 +96,7 @@ def flash(ctx, save_file_system, y, port, binary, no_poll, retry):
             if code or code == -1000:
                 break
             tries += 1
+            click.echo('Retrying...')
 
 
 def find_binary(path):

--- a/proscli/flasher.py
+++ b/proscli/flasher.py
@@ -91,7 +91,10 @@ def flash(ctx, save_file_system, y, port, binary, no_poll, retry):
     click.echo('Flashing ' + binary + ' to ' + ', '.join(port))
     for p in port:
         tries = 1
-        while not prosflasher.upload.upload(p, binary, no_poll, ctx) and tries <= retry:
+        while tries <= retry:
+            code = prosflasher.upload.upload(p, y, binary, no_poll, ctx)
+            if code or code == -1000:
+                break
             tries += 1
 
 

--- a/proscli/flasher.py
+++ b/proscli/flasher.py
@@ -7,6 +7,7 @@ import prosflasher.ports
 import prosflasher.upload
 import prosconfig
 from proscli.utils import default_cfg, AliasGroup
+from proscli.utils import get_version
 
 
 @click.group(cls=AliasGroup)
@@ -42,6 +43,7 @@ def flash(ctx, save_file_system, y, port, binary, no_poll, retry):
     By default, the CLI will look around for a proper binary to upload to the microcontroller. If one was not found, or
     if you want to change the default binary, you can specify it.
     """
+    click.echo(' ====:: PROS Flasher v{} ::===='.format(get_version()))
     if port == 'auto':
         ports = prosflasher.ports.list_com_ports()
         if len(ports) == 0:

--- a/proscli/flasher.py
+++ b/proscli/flasher.py
@@ -90,7 +90,9 @@ def flash(ctx, save_file_system, y, port, binary, no_poll, retry):
 
     click.echo('Flashing ' + binary + ' to ' + ', '.join(port))
     for p in port:
-        prosflasher.upload.upload(p, binary, no_poll, ctx, retry)
+        tries = 1
+        while not prosflasher.upload.upload(p, binary, no_poll, ctx) and tries <= retry:
+            tries += 1
 
 
 def find_binary(path):

--- a/proscli/flasher.py
+++ b/proscli/flasher.py
@@ -92,11 +92,11 @@ def flash(ctx, save_file_system, y, port, binary, no_poll, retry):
     for p in port:
         tries = 1
         while tries <= retry:
+            click.echo('Retrying...')
             code = prosflasher.upload.upload(p, y, binary, no_poll, ctx)
             if code or code == -1000:
                 break
             tries += 1
-            click.echo('Retrying...')
 
 
 def find_binary(path):

--- a/proscli/main.py
+++ b/proscli/main.py
@@ -1,10 +1,7 @@
 import click
 #from pkg_resources import get_distribution
 import proscli
-from proscli.utils import default_options
-import os.path
-import sys
-
+from proscli.utils import default_options, get_version
 
 def main():
     # the program name should always be pros. don't care if it's not...
@@ -12,22 +9,6 @@ def main():
         cli.main(prog_name='pros')
     except KeyboardInterrupt:
         click.echo('Aborted!')
-
-
-def get_version():
-    try:
-        if os.path.isfile(os.path.join(__file__, '../../version')):
-            return open(os.path.join(__file__, '../../version')).read().strip()
-    except Exception:
-        pass
-    try:
-        if getattr(sys, 'frozen', False):
-            import BUILD_CONSTANTS
-            return BUILD_CONSTANTS.CLI_VERSION
-    except Exception:
-        pass
-    return None # Let click figure it out
-
 
 @click.command('pros',
                cls=click.CommandCollection,

--- a/proscli/terminal.py
+++ b/proscli/terminal.py
@@ -1,6 +1,7 @@
 import click
 import proscli.serial_terminal
 import prosflasher.ports
+import serial
 import signal
 import sys
 import time
@@ -28,7 +29,7 @@ def terminal(port):
             click.echo('No ports were found.')
             click.get_current_context().abort()
             sys.exit()
-    ser = prosflasher.ports.create_serial(port)
+    ser = prosflasher.ports.create_serial(port, serial.PARITY_NONE)
     term = proscli.serial_terminal.Terminal(ser)
     signal.signal(signal.SIGINT, term.stop)
     term.start()

--- a/proscli/utils.py
+++ b/proscli/utils.py
@@ -1,8 +1,25 @@
+import os
+
 import click
+import sys
+
 from proscli.state import State
 
 pass_state = click.make_pass_decorator(State)
 
+def get_version():
+    try:
+        if os.path.isfile(os.path.join(__file__, '../../version')):
+            return open(os.path.join(__file__, '../../version')).read().strip()
+    except Exception:
+        pass
+    try:
+        if getattr(sys, 'frozen', False):
+            import BUILD_CONSTANTS
+            return BUILD_CONSTANTS.CLI_VERSION
+    except Exception:
+        pass
+    return None # Let click figure it out
 
 def verbosity_option(f):
     """

--- a/prosflasher/bootloader.py
+++ b/prosflasher/bootloader.py
@@ -95,7 +95,7 @@ def read_memory(port, start_address, size=0x100):
 
 
 def erase_flash(port):
-    click.echo('Erasing user flash...', nl=False)
+    click.echo('Erasing user flash... ', nl=False)
     prosflasher.upload.configure_port(port, serial.PARITY_EVEN)
     response = send_bootloader_command(port, 0x43, 1)
     if response is None or response[0] != 0x79:
@@ -162,7 +162,7 @@ def upload_binary(port, file):
 
 
 def send_go_command(port, address):
-    click.echo('Executing binary...', nl=False)
+    click.echo('Executing binary... ', nl=False)
     address = compute_address_commandable(address)
     debug('Executing binary at {}'.format(adr_to_str(address)))
 

--- a/prosflasher/bootloader.py
+++ b/prosflasher/bootloader.py
@@ -199,7 +199,7 @@ def send_go_command(port, address, retry=3):
     response = port.read(1)
     debug_response(adr_to_str(c_addr), response)
     if response is None or len(response) < 1 or response[0] != ACK:
-        click.echo('failed to start binary. May need to restart Cortex')
+        click.echo('binary might not have started properly. May need to restart Cortex')
     else:
         click.echo('complete')
     return True

--- a/prosflasher/bootloader.py
+++ b/prosflasher/bootloader.py
@@ -96,7 +96,7 @@ def read_memory(port, start_address, size=0x100):
 
 def erase_flash(port):
     click.echo('Erasing user flash... ', nl=False)
-    prosflasher.upload.configure_port(port, serial.PARITY_EVEN)
+    port.flush()
     response = send_bootloader_command(port, 0x43, 1)
     if response is None or response[0] != 0x79:
         click.echo('failed')
@@ -174,5 +174,3 @@ def send_go_command(port, address):
     port.flush()
     click.echo('complete')
     return True
-
-

--- a/prosflasher/bootloader.py
+++ b/prosflasher/bootloader.py
@@ -44,7 +44,7 @@ def compute_address_commandable(address):
 
 
 def prepare_bootloader(port):
-    click.echo('Preparing bootloader...', nl=False)
+    click.echo('Preparing bootloader... ', nl=False)
     prosflasher.upload.configure_port(port, serial.PARITY_EVEN)
     port.flush()
     port.write([0x7f])

--- a/prosflasher/bootloader.py
+++ b/prosflasher/bootloader.py
@@ -184,7 +184,7 @@ def upload_binary(port, file):
 
 
 def send_go_command(port, address, retry=3):
-    click.echo('Executing binary... ', nl=False)
+    click.echo('Executing user code... ', nl=False)
     c_addr = compute_address_commandable(address)
     debug('Executing binary at {}'.format(adr_to_str(c_addr)))
 
@@ -199,7 +199,7 @@ def send_go_command(port, address, retry=3):
     response = port.read(1)
     debug_response(adr_to_str(c_addr), response)
     if response is None or len(response) < 1 or response[0] != ACK:
-        click.echo('binary might not have started properly. May need to restart Cortex')
+        click.echo('user code might not have started properly. May need to restart Cortex')
     else:
         click.echo('complete')
     return True

--- a/prosflasher/bootloader.py
+++ b/prosflasher/bootloader.py
@@ -146,9 +146,10 @@ def write_flash(port, start_address, data, retry=2):
     checksum = len(data) - 1
     for x in data:
         checksum ^= x
-    data.insert(0, len(data) - 1)
-    data.append(checksum)
-    port.write(data)
+    send_data = data
+    send_data.insert(0, len(send_data) - 1)
+    send_data.append(checksum)
+    port.write(send_data)
     time.sleep(0.005)
     response = port.read(1)
     debug('STM BL RESPONSE TO WRITE: {}'.format(response))

--- a/prosflasher/bootloader.py
+++ b/prosflasher/bootloader.py
@@ -19,9 +19,8 @@ def debug_response(command, response, fmt='STM BL RESPONSE TO 0x{}: {}'):
 
 def send_bootloader_command(port, command, response_size=1):
     port.write([command, 0xff - command])
-    port.flush()
+    time.sleep(0.01)
     response = port.read(response_size)
-    debug_response(command, response)
     return response
 
 
@@ -45,21 +44,31 @@ def compute_address_commandable(address):
 
 def prepare_bootloader(port):
     click.echo('Preparing bootloader... ', nl=False)
-    prosflasher.upload.configure_port(port, serial.PARITY_EVEN)
-    port.flush()
-    port.write([0x7f])
-    response = port.read(1)
-    debug_response(0x07f, response)
-    if response is None or len(response) != 1 or response[0] != ACK:
-        click.echo('failed')
-        return False
-    click.echo('complete')
-    if click.get_current_context().obj.verbosity > 1:
-        click.echo('Extra commands:')
-        send_bootloader_command(port, 0x00, 15)
-        send_bootloader_command(port, 0x01, 5)
-        send_bootloader_command(port, 0x02, 5)
-    return True
+    # for _ in range(0, 3):
+    #     response = send_bootloader_command(port, 0x00, 15)
+    #     if response is not None and len(response) == 15 and response[0] == ACK and response[-1] == ACK:
+    #         click.echo('complete')
+    #         return True
+    time.sleep(0.01)
+    port.rts = 0
+    time.sleep(0.01)
+    for _ in range(0,3):
+        port.write([0x7f])
+        response = port.read(1)
+        debug_response(0x7f, response)
+        if not (response is None or len(response) != 1 or response[0] != ACK):
+            time.sleep(0.01)
+            response = send_bootloader_command(port, 0x00, 15)
+            debug_response(0x00, response)
+            if response is None or len(response) != 15 or response[0] != ACK or response[-1] != ACK:
+                click.echo('failed (couldn\'t verify commands)')
+                return False
+            # send_bootloader_command(port, 0x01, 5)
+            # send_bootloader_command(port, 0x02, 5)
+            click.echo('complete')
+            return True
+    click.echo('failed')
+    return False
 
 
 def read_memory(port, start_address, size=0x100):
@@ -98,36 +107,42 @@ def erase_flash(port):
     click.echo('Erasing user flash... ', nl=False)
     port.flush()
     response = send_bootloader_command(port, 0x43, 1)
-    if response is None or response[0] != 0x79:
+    if response is None or len(response) < 1 or response[0] != 0x79:
         click.echo('failed')
         return False
+    time.sleep(0.01)
     response = send_bootloader_command(port, 0xff, 1)
-    if response is None or response[0] != 0x79:
-        click.echo('failed')
+    debug_response(0xff, response)
+    if response is None or len(response) < 1 or response[0] != 0x79:
+        click.echo('failed (address unacceptable)')
         return False
     click.echo('complete')
     return True
 
 
-def write_flash(port, start_address, data):
+def write_flash(port, start_address, data, retry=2):
     data = bytearray(data)
     if len(data) > 256:
         click.echo('Tried writing too much data at once! ({} bytes)'.format(len(data)))
         return False
     port.read_all()
-    start_address = compute_address_commandable(start_address)
-    debug('Writing {} bytes to {}'.format(len(data), adr_to_str(start_address)))
+    c_addr = compute_address_commandable(start_address)
+    debug('Writing {} bytes to {}'.format(len(data), adr_to_str(c_addr)))
     response = send_bootloader_command(port, 0x31)
-    if response is None or response[0] != ACK:
+    if response is None or len(response) < 1 or response[0] != ACK:
         click.echo('failed (write command not accepted)')
         return False
-    port.write(start_address)
+    port.write(c_addr)
     port.flush()
     response = port.read(1)
-    debug_response(adr_to_str(start_address), response)
-    if response is None or response[0] != ACK:
-        click.echo('failed (address not accepted)')
-        return False
+    debug_response(adr_to_str(c_addr), response)
+    if response is None or len(response) < 1 or response[0] != ACK:
+        if retry > 0:
+            debug('RETRYING PACKET')
+            write_flash(port, start_address, data, retry=retry - 1)
+        else:
+            click.echo('failed (address not accepted)')
+            return False
     checksum = len(data) - 1
     for x in data:
         checksum ^= x
@@ -136,16 +151,23 @@ def write_flash(port, start_address, data):
     port.write(data)
     time.sleep(0.005)
     response = port.read(1)
-    if response is None or response[0] != ACK:
-        port.write(data)
-        time.sleep(20)
-        response = port.read(1)
-        if response is None or response[0] != ACK:
+    debug('STM BL RESPONSE TO WRITE: {}'.format(response))
+    if response is None or len(response) < 1 or response[0] != ACK:
+        if retry > 0:
+            debug('RETRYING PACKET')
+            write_flash(port, start_address, data, retry=retry - 1)
+        else:
             click.echo('failed (could not complete upload)')
             return False
     port.flush()
     port.reset_input_buffer()
     return True
+
+
+def chunks(l, n):
+    """Yield successive n-sized chunks from l."""
+    for i in range(0, len(l), n):
+        yield l[i:i + n]
 
 
 def upload_binary(port, file):
@@ -161,16 +183,23 @@ def upload_binary(port, file):
     return True
 
 
-def send_go_command(port, address):
+def send_go_command(port, address, retry=3):
     click.echo('Executing binary... ', nl=False)
-    address = compute_address_commandable(address)
-    debug('Executing binary at {}'.format(adr_to_str(address)))
+    c_addr = compute_address_commandable(address)
+    debug('Executing binary at {}'.format(adr_to_str(c_addr)))
 
     response = send_bootloader_command(port, 0x21, 1)
-    if response is None or response[0] != ACK:
+    debug_response(0x21, response)
+    if response is None or len(response) < 1 or response[0] != ACK:
         click.echo('failed (execute command not accepted)')
         return False
-    port.write(address)
-    port.flush()
-    click.echo('complete')
+    time.sleep(0.01)
+    port.write(c_addr)
+    time.sleep(0.01)
+    response = port.read(1)
+    debug_response(adr_to_str(c_addr), response)
+    if response is None or len(response) < 1 or response[0] != ACK:
+        click.echo('failed to start binary. May need to restart Cortex')
+    else:
+        click.echo('complete')
     return True

--- a/prosflasher/ports.py
+++ b/prosflasher/ports.py
@@ -20,21 +20,26 @@ def create_serial(port):
     """
     Creates and/or configures a serial port to communicate with the Cortex Microcontroller
     :param port: A serial.Serial object, a device string identifier will create a corresponding serial port.
-        Anything elsse will create a default serial port with no device assigned.
+        Anything else will create a default serial port with no device assigned.
     :return: Returns a correctly configured instance of a serial.Serial object, potentially with a correctly configured
         device iff a correct port value was passed in
     """
+    # port_str = ''
     if isinstance(port, str):
         try:
+            click.echo('got port string as expected')
+            # port_str = port
             port = serial.Serial(port)
         except serial.SerialException as e:
             click.echo('WARNING: {}'.format(e))
             port = serial.Serial()
     elif not isinstance(port, serial.Serial):
+        click.echo('port was not string, send help')
         port = serial.Serial()
 
     assert isinstance(port, serial.Serial)
 
+    # port.port = port_str if port_str != '' else None
     port.baudrate = BAUD_RATE
     port.bytesize = serial.EIGHTBITS
     port.parity = serial.PARITY_EVEN
@@ -45,13 +50,13 @@ def create_serial(port):
     port.dsrdtr = False
     # port.write_timeout = 5.0
     # port.inter_byte_timeout = 0.005  # todo make sure this is seconds
-
+    click.echo(port)
     return port
 
 
 def create_port_list(verbose=False):
     """
-    Returns a formatted string of all COM ports we believe are valid Cortex ports, delimted by \n
+    Returns a formatted string of all COM ports we believe are valid Cortex ports, delimited by \n
     :param verbose: If True, then the hwid will be added to the end of each device
     :return: A formatted string for printing describing the COM ports
     """

--- a/prosflasher/ports.py
+++ b/prosflasher/ports.py
@@ -27,7 +27,6 @@ def create_serial(port):
     # port_str = ''
     if isinstance(port, str):
         try:
-            click.echo('got port string as expected')
             # port_str = port
             port = serial.Serial(port)
         except serial.SerialException as e:
@@ -50,7 +49,6 @@ def create_serial(port):
     port.dsrdtr = False
     # port.write_timeout = 5.0
     # port.inter_byte_timeout = 0.005  # todo make sure this is seconds
-    click.echo(port)
     return port
 
 

--- a/prosflasher/ports.py
+++ b/prosflasher/ports.py
@@ -16,7 +16,7 @@ def list_com_ports():
     return [x for x in serial.tools.list_ports.comports() if x.vid is not None and (x.vid in USB_VID or 'vex' in x.product.lower())]
 
 
-def create_serial(port):
+def create_serial(port, parity):
     """
     Creates and/or configures a serial port to communicate with the Cortex Microcontroller
     :param port: A serial.Serial object, a device string identifier will create a corresponding serial port.
@@ -28,27 +28,20 @@ def create_serial(port):
     if isinstance(port, str):
         try:
             # port_str = port
-            port = serial.Serial(port)
+            port = serial.Serial(port, baudrate=BAUD_RATE, bytesize=serial.EIGHTBITS, parity=parity, stopbits=serial.STOPBITS_ONE)
         except serial.SerialException as e:
             click.echo('WARNING: {}'.format(e))
-            port = serial.Serial()
+            port = serial.Serial(baudrate=BAUD_RATE, bytesize=serial.EIGHTBITS, parity=parity, stopbits=serial.STOPBITS_ONE)
     elif not isinstance(port, serial.Serial):
         click.echo('port was not string, send help')
-        port = serial.Serial()
+        port = serial.Serial(baudrate=BAUD_RATE, bytesize=serial.EIGHTBITS, parity=parity, stopbits=serial.STOPBITS_ONE)
 
     assert isinstance(port, serial.Serial)
 
     # port.port = port_str if port_str != '' else None
-    port.baudrate = BAUD_RATE
-    port.bytesize = serial.EIGHTBITS
-    port.parity = serial.PARITY_EVEN
-    port.stopbits = serial.STOPBITS_ONE
-    port.timeout = 5.0
-    port.xonxoff = False
-    port.rtscts = True
-    port.dsrdtr = False
+    port.timeout = 0.5
     # port.write_timeout = 5.0
-    # port.inter_byte_timeout = 0.005  # todo make sure this is seconds
+    port.inter_byte_timeout = 0.1  # todo make sure this is seconds
     return port
 
 

--- a/prosflasher/ports.py
+++ b/prosflasher/ports.py
@@ -45,7 +45,7 @@ def create_serial(port):
     port.stopbits = serial.STOPBITS_ONE
     port.timeout = 5.0
     port.xonxoff = False
-    port.rtscts = False
+    port.rtscts = True
     port.dsrdtr = False
     # port.write_timeout = 5.0
     # port.inter_byte_timeout = 0.005  # todo make sure this is seconds

--- a/prosflasher/upload.py
+++ b/prosflasher/upload.py
@@ -164,7 +164,8 @@ def ask_sys_info(port, ctx=proscli.utils.State(), silent=False):
             if response[10] > 5:  # anything smaller than 5 is probably garbage from ADC
                 sys_info.backup_battery = response[10] * 0.059
             try:
-                sys_info.connection_type = ConnectionType(response[11])
+                # Mask FCS bits out of response[11]
+                sys_info.connection_type = ConnectionType(response[11] & 0b00110011)
             except ValueError:
                 sys_info.connection_type = ConnectionType.unknown
             sys_info.previous_polls = response[13]

--- a/prosflasher/upload.py
+++ b/prosflasher/upload.py
@@ -165,7 +165,7 @@ def ask_sys_info(port, ctx=proscli.utils.State(), silent=False):
                 sys_info.backup_battery = response[10] * 0.059
             try:
                 # Mask FCS bits out of response[11]
-                sys_info.connection_type = ConnectionType(response[11] & 0b00110011)
+                sys_info.connection_type = ConnectionType(response[11] & 0b00110111)
             except ValueError:
                 sys_info.connection_type = ConnectionType.unknown
             sys_info.previous_polls = response[13]

--- a/prosflasher/upload.py
+++ b/prosflasher/upload.py
@@ -118,7 +118,7 @@ def upload(port, y, binary, no_poll=False, ctx=proscli.utils.State()):
 
 def stop_user_code(port, ctx=proscli.utils.State()):
     # Noticed no appreciable difference between having this here and not during testing
-    # reset_cortex(port, ctx)
+    reset_cortex(port, ctx)
     # leaving it in in case we find out later it's necessary
     click.echo('Stopping user code... ', nl=False)
     stopbits = [0x0f, 0x0f, 0x21, 0xde, 0x08, 0x00, 0x00, 0x00, 0x08, 0xf1, 0x04]
@@ -145,7 +145,7 @@ def ask_sys_info(port, ctx=proscli.utils.State()):
     configure_port(port, serial.PARITY_NONE)
     debug('SYS INFO BITS: {}  PORT CFG: {}'.format(bytes_to_str(sys_info_bits), repr(port)), ctx)
     for _ in itertools.repeat(None, 10):
-        port.read(port.in_waiting)
+        port.read_all()
         port.write(sys_info_bits)
         port.flush()
         time.sleep(0.1)

--- a/prosflasher/upload.py
+++ b/prosflasher/upload.py
@@ -62,7 +62,7 @@ Joystick: F/W {} w/ {:1.2f}V
 
 
 # THIS MANAGES THE UPLOAD PROCESS FOR A GIVEN PORT/BINARY PAIR
-def upload(port, binary, no_poll=False, ctx=proscli.utils.State(), retry=2):
+def upload(port, binary, no_poll=False, ctx=proscli.utils.State()):
     if not os.path.isfile(binary):
         click.echo('Failed to download... file does not exist')
         return False

--- a/prosflasher/upload.py
+++ b/prosflasher/upload.py
@@ -106,13 +106,12 @@ def upload(port, binary, no_poll=False, ctx=proscli.utils.State(), retry=2):
             return False
 
         reset_cortex(port)
-
+        click.echo("Download complete!")
     except serial.serialutil.SerialException as e:
         click.echo('Failed to download code! ' + str(e))
     finally:
         port.close()
-    click.echo("Download complete!")
-    pass
+
 
 
 def stop_user_code(port, ctx=proscli.utils.State()):

--- a/prosflasher/upload.py
+++ b/prosflasher/upload.py
@@ -117,10 +117,6 @@ def upload(port, y, binary, no_poll=False, ctx=proscli.utils.State()):
 
 
 def stop_user_code(port, ctx=proscli.utils.State()):
-    # Noticed no appreciable difference between having this here and not during testing
-    reset_cortex(port, ctx)
-    openshut(port)
-    # leaving it in in case we find out later it's necessary
     click.echo('Stopping user code... ', nl=False)
     stopbits = [0x0f, 0x0f, 0x21, 0xde, 0x08, 0x00, 0x00, 0x00, 0x08, 0xf1, 0x04]
     debug(bytes_to_str(stopbits), ctx)

--- a/prosflasher/upload.py
+++ b/prosflasher/upload.py
@@ -190,7 +190,8 @@ def send_to_download_channel(port, ctx=proscli.utils.State()):
         response = port.read_all()
         debug('DB CH RESPONSE: {}'.format(bytes_to_str(response)), ctx)
         response = response[-1:]
-        if ask_sys_info(port, ctx, silent=True).connection_type == ConnectionType.serial_vexnet2_dl or (response is not None and len(response) > 0 and response[0] == ACK):
+        sys_info = ask_sys_info(port, ctx, silent=True)
+        if (sys_info is not None and sys_info.connection_type == ConnectionType.serial_vexnet2_dl) or (response is not None and len(response) > 0 and response[0] == ACK):
             click.echo('complete')
             return True
     click.echo('failed')
@@ -287,3 +288,14 @@ def openshut(port):
         port.close()
         time.sleep(0.1)
     port.open()
+
+def pulse_rts(port):
+    # @jpearman
+    port.rts = True
+    time.sleep(0.005)
+    port.rts = False
+    time.sleep(0.015)
+    port.rts = True
+    time.sleep(0.030)
+    port.rts = False
+    time.sleep(0.025)

--- a/prosflasher/upload.py
+++ b/prosflasher/upload.py
@@ -119,6 +119,7 @@ def upload(port, y, binary, no_poll=False, ctx=proscli.utils.State()):
 def stop_user_code(port, ctx=proscli.utils.State()):
     # Noticed no appreciable difference between having this here and not during testing
     reset_cortex(port, ctx)
+    openshut(port)
     # leaving it in in case we find out later it's necessary
     click.echo('Stopping user code... ', nl=False)
     stopbits = [0x0f, 0x0f, 0x21, 0xde, 0x08, 0x00, 0x00, 0x00, 0x08, 0xf1, 0x04]
@@ -194,12 +195,12 @@ def send_to_download_channel(port, ctx=proscli.utils.State()):
         if response is not None and len(response) > 0 and response[0] == ACK:
             click.echo('complete')
             return True
-    click.echo('complete')
+    click.echo('failed')
     return False
 
 
 def expose_bootloader(port, ctx=proscli.utils.State()):
-    click.echo('Exposing bootloader... ', nl=False)
+    click.echo('Exposing bootloader...', nl=False)
     bootloader_bits = [0xc9, 0x36, 0xb8, 0x47, 0x25]
     configure_port(port, serial.PARITY_NONE)
     port.flush()
@@ -231,9 +232,7 @@ def reset_cortex(port, ctx=proscli.utils.State()):
 def configure_port(port, parity):
     port.reset_input_buffer()
     port.reset_output_buffer()
-    # if port.is_open:
-    #     port.close()
-    # port.open()
+    openshut(port)
     port.parity = parity
     port.BAUDRATES = prosflasher.ports.BAUD_RATE
 
@@ -284,3 +283,9 @@ def dump_cortex(port, file, verbose=False):
         port.close()
     click.echo("Download complete!")
     pass
+
+def openshut(port):
+    if port.is_open:
+        port.close()
+        time.sleep(0.1)
+    port.open()

--- a/prosflasher/upload.py
+++ b/prosflasher/upload.py
@@ -207,7 +207,7 @@ def expose_bootloader(port, ctx=proscli.utils.State()):
     debug('EXPOSE BL BITS: {}  PORT CFG: {}'.format(bytes_to_str(bootloader_bits), repr(port)), ctx)
     port.read_all()
     time.sleep(0.1)
-    for _ in itertools.repeat(None, 5):
+    for _ in itertools.repeat(None, 6):
         port.write(bootloader_bits)
         port.flush()
     configure_port(port, serial.PARITY_NONE)

--- a/prosflasher/upload.py
+++ b/prosflasher/upload.py
@@ -71,7 +71,6 @@ def upload(port, y, binary, no_poll=False, ctx=proscli.utils.State()):
         click.echo('Failed to download: port not found')
         return
     try:
-        click.echo(port)
         stop_user_code(port, ctx)
         if not no_poll:
             sys_info = ask_sys_info(port, ctx)
@@ -121,7 +120,6 @@ def stop_user_code(port, ctx=proscli.utils.State()):
     click.echo('Stopping user code... ', nl=False)
     stopbits = [0x0f, 0x0f, 0x21, 0xde, 0x08, 0x00, 0x00, 0x00, 0x08, 0xf1, 0x04]
     debug(bytes_to_str(stopbits), ctx)
-    click.echo(port)
     if not port.is_open:
         port.open()
     port.flush()

--- a/prosflasher/upload.py
+++ b/prosflasher/upload.py
@@ -109,15 +109,17 @@ def upload(port, y, binary, no_poll=False, ctx=proscli.utils.State()):
         return True
     except serial.serialutil.SerialException as e:
         click.echo('Failed to download code! ' + str(e))
-        click.echo('Try unplugging and plugging the USB cable back in, as well as power-cycling the microcontroller.')
-        return -1000 # stop retries in this case, because there's a problem with the port
+        click.echo('Try unplugging and plugging the USB cable back in,'
+                   ' as well as power-cycling the microcontroller.')
+        return -1000  # stop retries in this case, because there's a problem with the port
     finally:
         port.close()
 
 
-
 def stop_user_code(port, ctx=proscli.utils.State()):
-    reset_cortex(port, ctx)
+    # Noticed no appreciable difference between having this here and not during testing
+    # reset_cortex(port, ctx)
+    # leaving it in in case we find out later it's necessary
     click.echo('Stopping user code... ', nl=False)
     stopbits = [0x0f, 0x0f, 0x21, 0xde, 0x08, 0x00, 0x00, 0x00, 0x08, 0xf1, 0x04]
     debug(bytes_to_str(stopbits), ctx)
@@ -282,5 +284,3 @@ def dump_cortex(port, file, verbose=False):
         port.close()
     click.echo("Download complete!")
     pass
-
-

--- a/prosflasher/upload.py
+++ b/prosflasher/upload.py
@@ -126,7 +126,7 @@ def stop_user_code(port, ctx=proscli.utils.State()):
     if not port.is_open:
         port.open()
     port.flush()
-    port.read(port.in_waiting)
+    port.read_all()
     time.sleep(0.1)
     for stopbit in stopbits:
         port.write([stopbit])
@@ -204,7 +204,7 @@ def expose_bootloader(port, ctx=proscli.utils.State()):
     configure_port(port, serial.PARITY_NONE)
     port.flush()
     debug('EXPOSE BL BITS: {}  PORT CFG: {}'.format(bytes_to_str(bootloader_bits), repr(port)), ctx)
-    port.read(port.in_waiting)
+    port.read_all()
     time.sleep(0.1)
     for _ in itertools.repeat(None, 5):
         port.write(bootloader_bits)
@@ -220,7 +220,7 @@ def reset_cortex(port, ctx=proscli.utils.State()):
     configure_port(port, serial.PARITY_NONE)
     debug('RESET CORTEX. PORT CFG: {}'.format(repr(port)), ctx)
     port.flush()
-    port.read(port.in_waiting)
+    port.read_all()
     time.sleep(0.1)
     port.write([20])
     port.flush()

--- a/prosflasher/upload.py
+++ b/prosflasher/upload.py
@@ -230,11 +230,11 @@ def reset_cortex(port, ctx=proscli.utils.State()):
 
 
 def configure_port(port, parity):
-    port.reset_input_buffer()
-    port.reset_output_buffer()
-    openshut(port)
-    port.parity = parity
-    port.BAUDRATES = prosflasher.ports.BAUD_RATE
+    if os.name == 'nt':
+        port.reset_input_buffer()
+        port.reset_output_buffer()
+        port.parity = parity
+    port.flush()
 
 
 def verify_file(file):
@@ -284,19 +284,3 @@ def dump_cortex(port, file, verbose=False):
     click.echo("Download complete!")
     pass
 
-def openshut(port):
-    if port.is_open:
-        port.close()
-        time.sleep(0.1)
-    port.open()
-
-def pulse_rts(port):
-    # @jpearman
-    port.rts = True
-    time.sleep(0.005)
-    port.rts = False
-    time.sleep(0.015)
-    port.rts = True
-    time.sleep(0.030)
-    port.rts = False
-    time.sleep(0.025)

--- a/prosflasher/upload.py
+++ b/prosflasher/upload.py
@@ -124,6 +124,7 @@ def stop_user_code(port, ctx=proscli.utils.State()):
         port.open()
     port.flush()
     port.read(port.in_waiting)
+    time.sleep(0.1)
     for stopbit in stopbits:
         port.write([stopbit])
     port.flush()
@@ -200,6 +201,7 @@ def expose_bootloader(port, ctx=proscli.utils.State()):
     port.flush()
     debug('EXPOSE BL BITS: {}  PORT CFG: {}'.format(bytes_to_str(bootloader_bits), repr(port)), ctx)
     port.read(port.in_waiting)
+    time.sleep(0.1)
     for _ in itertools.repeat(None, 5):
         port.write(bootloader_bits)
         port.flush()
@@ -215,6 +217,7 @@ def reset_cortex(port, ctx=proscli.utils.State()):
     debug('RESET CORTEX. PORT CFG: {}'.format(repr(port)), ctx)
     port.flush()
     port.read(port.in_waiting)
+    time.sleep(0.1)
     port.write([20])
     port.flush()
     click.echo('complete')

--- a/prosflasher/upload.py
+++ b/prosflasher/upload.py
@@ -222,7 +222,7 @@ def reset_cortex(port, ctx=proscli.utils.State()):
     port.flush()
     port.read_all()
     time.sleep(0.1)
-    port.write([20])
+    port.write([0x20])
     port.flush()
     click.echo('complete')
     time.sleep(0.01)

--- a/prosflasher/upload.py
+++ b/prosflasher/upload.py
@@ -62,7 +62,7 @@ Joystick: F/W {} w/ {:1.2f}V
 
 
 # THIS MANAGES THE UPLOAD PROCESS FOR A GIVEN PORT/BINARY PAIR
-def upload(port, binary, no_poll=False, ctx=proscli.utils.State()):
+def upload(port, binary, no_poll=False, ctx=proscli.utils.State(), retry=2):
     if not os.path.isfile(binary):
         click.echo('Failed to download... file does not exist')
         return False


### PR DESCRIPTION
Added a `-r` switch to the `pros flash` command so users can specify a number of times to retry failed downloads (default is to retry twice).

logic is as follows:
if an upload fails, loop until either an upload succeeds or the specified number of retries is reached.

From my testing (I was testing over VEXnet 2.0, as direct A-to-A produced no consistent problems for me), retrying just once worked the vast majority of the time. However, I did encounter an error that would occur after flashing many times (way more than in a real situation, I ~hope~ think), where `pyserial` would raise an error saying something like `The port must be configured before it can be used`. The cause of this error is a `serial.Serial()` object's `_port` property became suddenly unset. Not sure what made this happen, but the only solution I could come up with was to unplug the controller, power-cycle the cortex, and plug the controller back in (I also made the flasher say as much when it encounters this error).

Needless to say, more testing would be appreciated.