### PR TITLE
Fix filename matching when creating/upgrading projects

### DIFF
--- a/proscli/conductor_management.py
+++ b/proscli/conductor_management.py
@@ -23,8 +23,8 @@ import jsonpickle
 def create_template(cfg, name, version, depot, location, ignore, upgrade_files):
     first_run(cfg)
     template = local.create_template(utils.Identifier(name, version, depot), location=location)
-    template.template_ignore = ignore
-    template.upgrade_paths = upgrade_files
+    template.template_ignore = list(ignore)
+    template.upgrade_paths = list(upgrade_files)
     template.save()
     click.echo(jsonpickle.encode(template))
     click.echo('Created template at {}'.format(template.save_file))

--- a/prosconductor/providers/local.py
+++ b/prosconductor/providers/local.py
@@ -144,27 +144,27 @@ def upgrade_project(identifier, dest, pros_cli=None):
     config = TemplateConfig(file=filename)
     for root, dirs, files in os.walk(config.directory):
         for d in dirs:
+            f = os.path.relpath(os.path.join(root, d), config.directory)
             if any([fnmatch.fnmatch(d, p) for p in config.upgrade_paths]):
                 verbose('Upgrading {}'.format(d))
-                relpath = os.path.relpath(os.path.join(root, d), config.directory)
-                shutil.copytree(os.path.join(config.directory, relpath), os.path.join(proj_config.directory, relpath))
+                shutil.copytree(os.path.join(config.directory, f), os.path.join(proj_config.directory, f))
         for f in files:
+            f = os.path.relpath(os.path.join(root, f), config.directory)
             if any([fnmatch.fnmatch(f, p) for p in config.upgrade_paths]):
                 verbose('Upgrading {}'.format(f))
-                relpath = os.path.relpath(os.path.join(root, f), config.directory)
-                shutil.copyfile(os.path.join(config.directory, relpath), os.path.join(proj_config.directory, relpath))
+                shutil.copyfile(os.path.join(config.directory, f), os.path.join(proj_config.directory, f))
     for root, dirs, files in os.walk(proj_config.directory):
         for d in dirs:
+            d = os.path.relpath(os.path.join(root, d), proj_config.directory)
             if any([fnmatch.fnmatch(d, p) for p in config.remove_paths]):
                 verbose('Removing {}'.format(d))
-                relpath = os.path.relpath(os.path.join(root, d), proj_config.directory)
-                shutil.rmtree(os.path.join(proj_config.directory, relpath))
+                shutil.rmtree(os.path.join(proj_config.directory, d))
 
         for f in files:
+            f = os.path.relpath(os.path.join(root, f), proj_config.directory)
             if any([fnmatch.fnmatch(f, p) for p in config.remove_paths]):
                 verbose('Removing {}'.format(f))
-                relpath = os.path.relpath(os.path.join(root, f), proj_config.directory)
-                os.remove(os.path.join(proj_config.directory, relpath))
+                os.remove(os.path.join(proj_config.directory, f))
     proj_config.kernel = config.identifier.version
     proj_config.save()
 

--- a/prosconductor/providers/local.py
+++ b/prosconductor/providers/local.py
@@ -117,10 +117,12 @@ def create_project(identifier, dest, pros_cli=None):
     copytree(config.directory, dest)
     for root, dirs, files in os.walk(dest):
         for d in dirs:
+            d = os.path.relpath(os.path.join(root, d), config.directory)
             if any([fnmatch.fnmatch(d, p) for p in config.template_ignore]):
                 verbose('Removing {}'.format(d))
                 os.rmdir(os.path.join(root, d))
         for f in files:
+            f = os.path.relpath(os.path.join(root, f), config.directory)
             if any([fnmatch.fnmatch(f, p) for p in config.template_ignore]):
                 verbose('Removing {}'.format(f))
                 os.remove(os.path.join(root, f))


### PR DESCRIPTION
Resolves issue raised by #29 

When scanning through the template directory of files to upload, we would check the filenames. So you'd get to `API.h` and check if it's something you want to upgrade. `include/API.h` wouldn't match `API.h`