### PR TITLE
Remove depot identifiers from templates

### DIFF
--- a/proscli/conductor.py
+++ b/proscli/conductor.py
@@ -65,7 +65,6 @@ def list_depots(cfg):
         if not bool(depots):
             click.echo('No depots currently registered! Use `pros conduct add-depot` to add a new depot')
         else:
-            click.echo([(d.name, d.registrar, d.location) for d in depots])
             click.echo(tabulate.tabulate([(d.name, d.registrar, d.location) for d in depots],
                                          ['Name', 'Registrar', 'Location'], tablefmt='simple'))
 
@@ -211,7 +210,7 @@ def list_templates(cfg, template_types, filters, offline_only):
             click.echo(json.dumps(table))
 
 
-@conduct.command(short_help='Download a template', aliases=['dl'])
+@conduct.command(short_help='Download a template', aliases=['dl', 'd'])
 @click.argument('name', default='kernel')
 @click.argument('version', default='latest')
 @click.argument('depot', default='auto')

--- a/proscli/conductor_management.py
+++ b/proscli/conductor_management.py
@@ -15,14 +15,13 @@ import jsonpickle
 @conduct.command('create-template', short_help='Creates a template with the specified name, version, and depot')
 @click.argument('name')
 @click.argument('version')
-@click.argument('depot')
-@click.option('--location')
+@click.argument('location')
 @click.option('--ignore', '-i', multiple=True)
 @click.option('--upgrade-files', '-u', multiple=True)
 @default_cfg
-def create_template(cfg, name, version, depot, location, ignore, upgrade_files):
+def create_template(cfg, name, version, location, ignore, upgrade_files):
     first_run(cfg)
-    template = local.create_template(utils.Identifier(name, version, depot), location=location)
+    template = local.create_template(utils.Identifier(name, version, None), location=location)
     template.template_ignore = list(ignore)
     template.upgrade_paths = list(upgrade_files)
     template.save()

--- a/proscli/conductor_management.py
+++ b/proscli/conductor_management.py
@@ -12,7 +12,7 @@ import jsonpickle
 # Commands in this module are typically for automation/IDE purposes and probably won't be used by front-end users
 
 
-@conduct.command('create-template', short_help='Creates a template with the specified name, version, and depot')
+@conduct.command('create-template', short_help='Creates a template with the specified name and version')
 @click.argument('name')
 @click.argument('version')
 @click.argument('location')

--- a/prosconductor/providers/__init__.py
+++ b/prosconductor/providers/__init__.py
@@ -101,9 +101,11 @@ class DepotProvider(object):
                      if os.path.isdir(os.path.join(self.config.directory, x))]:
             if TemplateTypes.kernel in template_types and 'template.pros' in os.listdir(item) and os.path.basename(item).startswith('kernel'):
                 template_config = TemplateConfig(os.path.join(item, 'template.pros'))
+                template_config.depot = self.config.name
                 result[TemplateTypes.kernel].add(template_config.identifier)
             elif TemplateTypes.library in template_types and 'template.pros' in os.listdir(item) and not os.path.basename(item).startswith('kernel'):
                 template_config = TemplateConfig(os.path.join(item, 'template.pros'))
+                template_config.depot = self.config.name
                 result[TemplateTypes.library].add(template_config.identifier)
         return result
 


### PR DESCRIPTION
Before this change, a template required a depot name be specified. This
doesn't make any sense in the context of a template, since templates
shouldn't have any knowledge of their originating depot.

Since the template object does need to know what its originating depot
is, we needed to insert that information when we scan for local
templates.