### PR TITLE
Detect version mismatch in GitHub releases

### DIFF
--- a/proscli/conductor.py
+++ b/proscli/conductor.py
@@ -305,16 +305,18 @@ def download(cfg, name, version, depot, no_check):
                                                            identifier.version,
                                                            descriptor.depot.config.name,
                                                            descriptor.depot.registrar))
-    descriptor.depot.download(identifier)
-    if identifier.name == 'kernel':
-        click.echo('''To create a new PROS project with this kernel, run `pros conduct new <folder> {0} {1}`,
-or to upgrade an existing project, run `pros conduct upgrade <folder> {0} {1}'''
-                   .format(identifier.version, identifier.depot))
-        # todo: add helpful text for how to create a project or add the new library to a project
-
-
-
-
+    new_identifier = descriptor.depot.download(identifier)
+    if new_identifier == False:
+        click.echo('Failed to download {0} {1} from {2}'.format(identifier.version, identifier.version, identifier.depot))
+    else:
+        if new_identifier.name == 'kernel':
+            click.echo('''To create a new PROS project with this template, run `pros conduct new <folder> {0} {1}`,
+        or to upgrade an existing project, run `pros conduct upgrade <folder> {0} {1}'''
+                       .format(new_identifier.version, new_identifier.depot))
+        else:
+            click.echo('''To add this library to a PROS project, run `pros conduct add-lib <folder> {0} {1} {2},
+            or to upgrade an existing project with this library to the new version, run `pros conduct upgrade-lib <Folder> {0} {1} {2}'''
+                       .format(new_identifier.name, new_identifier.version, new_identifier.depot))
 
 # endregion
 
@@ -587,5 +589,6 @@ def upgradelib(cfg, location, library, version, depot):
 def first_run_cmd(cfg, no_force, use_defaults, no_download, apply_providers):
     first_run(cfg, force=no_force, defaults=use_defaults,
                    doDownload=no_download, reapplyProviders=apply_providers)
+
 
 import proscli.conductor_management

--- a/proscli/upgrade.py
+++ b/proscli/upgrade.py
@@ -14,9 +14,12 @@ def upgrade_cli():
 
 def get_upgrade_command():
     if getattr(sys, 'frozen', False):
-        cmd = os.path.abspath(os.path.join(sys.executable, '..', '..', 'updater.exe'))
-        if os.path.exists(cmd):
-            return [cmd, '-reducedgui']
+        if sys.platform == 'win32':
+            cmd = os.path.abspath(os.path.join(sys.executable, '..', '..', 'updater.exe'))
+            if os.path.exists(cmd):
+                return [cmd, '/reducedgui', '/checknow']
+            else:
+                return False
         else:
             return False
     else:

--- a/prosconductor/providers/githubreleases.py
+++ b/prosconductor/providers/githubreleases.py
@@ -6,7 +6,7 @@ import os
 import os.path
 import proscli.utils
 from prosconductor.providers import TemplateTypes, DepotProvider, InvalidIdentifierException, DepotConfig, Identifier, \
-    get_template_dir
+    get_template_dir, TemplateConfig
 import re
 import requests
 import requests.exceptions
@@ -141,8 +141,14 @@ class GithubReleasesDepotProvider(DepotProvider):
                                     zf.extract(file, path=template_dir)
                                     progress_bar.update(1)
                         os.remove(tf.name)
+                    template_config = TemplateConfig(os.path.join(template_dir, 'template.pros'))
+                    if template_config.identifier.version != identifier.version:
+                        click.echo('WARNING: Version fetched does not have the same version downloaded {0} != {1}.'
+                                   .format(template_config.identifier.version, identifier.version))
+                        os.rename(template_dir, get_template_dir(self, template_config.identifier))
+                        template_dir = get_template_dir(self, template_config.identifier)
                     click.echo('Template downloaded to {}'.format(template_dir))
-                    return True
+                    return template_config.identifier
                 else:
                     click.echo('Unable to download {} from {} (Status code: {})'.format(asset['name'],
                                                                                         self.config.location,


### PR DESCRIPTION
 - Add the helpful message for creating/upgrading libraries

When version mismatch is detect (i.e. release `2.12.1` tag, but the template.pros says `2.11.1-ga-11`), GHRel will rename the directory to `kernel-2.11.1-ga-11`, which makes the local provider work correctly.