### PR TITLE
Bug

### DIFF
--- a/proscli/conductor.py
+++ b/proscli/conductor.py
@@ -12,6 +12,7 @@ import prosconfig
 import semantic_version as semver
 import sys
 import tabulate
+import pdb
 
 
 # from typing import List
@@ -309,14 +310,15 @@ def download(cfg, name, version, depot, no_check):
     if new_identifier == False:
         click.echo('Failed to download {0} {1} from {2}'.format(identifier.version, identifier.version, identifier.depot))
     else:
-        if new_identifier.name == 'kernel':
+        pdb.set_trace()
+        if hasattr(identifier, 'name') and identifier.name == 'kernel':
             click.echo('''To create a new PROS project with this template, run `pros conduct new <folder> {0} {1}`,
         or to upgrade an existing project, run `pros conduct upgrade <folder> {0} {1}'''
-                       .format(new_identifier.version, new_identifier.depot))
+                       .format(identifier.version, identifier.depot))
         else:
             click.echo('''To add this library to a PROS project, run `pros conduct add-lib <folder> {0} {1} {2},
             or to upgrade an existing project with this library to the new version, run `pros conduct upgrade-lib <Folder> {0} {1} {2}'''
-                       .format(new_identifier.name, new_identifier.version, new_identifier.depot))
+                       .format(identifier.name, identifier.version, identifier.depot))
 
 # endregion
 

--- a/proscli/conductor.py
+++ b/proscli/conductor.py
@@ -12,7 +12,6 @@ import prosconfig
 import semantic_version as semver
 import sys
 import tabulate
-import pdb
 
 
 # from typing import List
@@ -310,7 +309,6 @@ def download(cfg, name, version, depot, no_check):
     if new_identifier == False:
         click.echo('Failed to download {0} {1} from {2}'.format(identifier.version, identifier.version, identifier.depot))
     else:
-        pdb.set_trace()
         if hasattr(identifier, 'name') and identifier.name == 'kernel':
             click.echo('''To create a new PROS project with this template, run `pros conduct new <folder> {0} {1}`,
         or to upgrade an existing project, run `pros conduct upgrade <folder> {0} {1}'''


### PR DESCRIPTION
I kept getting the traceback below. It seemed that `descriptor.depot.download(identifier)` returned `True`, not an instance of whatever `new_identifier` was. I made it keep the previous `identifier` settings. May not be the way to go, but it worked on my system.

```
Traceback (most recent call last):
  File "proscli/main.py", line 26, in <module>
    main()
  File "proscli/main.py", line 9, in main
    cli.main(prog_name='pros')
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/click/decorators.py", line 64, in new_func
    return ctx.invoke(f, obj, *args[1:], **kwargs)
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/Users/localhost/Downloads/pros-cli/proscli/conductor.py", line 593, in first_run_cmd
    doDownload=no_download, reapplyProviders=apply_providers)
  File "/Users/localhost/Downloads/pros-cli/proscli/conductor.py", line 33, in first_run
    click.get_current_context().invoke(download, name='kernel', depot='pros-mainline')
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/click/decorators.py", line 64, in new_func
    return ctx.invoke(f, obj, *args[1:], **kwargs)
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/Users/localhost/Downloads/pros-cli/proscli/conductor.py", line 314, in download
    if hasattr(new_identifier, 'name') and new_identifier.name == 'kernel':
AttributeError: 'bool' object has no attribute 'name'
```