### PR TITLE
Update setup.py to be able to install on pip 10+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,6 @@
 from setuptools import setup
 
 # setup.py for non-frozen builds
-from pip.req import parse_requirements
-install_reqs = [str(r.req) for r in parse_requirements('requirements.txt', session=False)]
 
 setup(
     name='pros-cli',
@@ -13,7 +11,15 @@ setup(
     author='Purdue ACM SIGBots',
     author_email='pros_development@cs.purdue.edu',
     description='Command Line Interface for managing PROS projects',
-    install_requires=install_reqs,
+    install_requires=[
+        'click',
+        'pyserial',
+        'cachetools',
+        'requests',
+        'tabulate',
+        'jsonpickle',
+        'semantic_version'
+    ],
     entry_points="""
         [console_scripts]
         pros=proscli.main:main


### PR DESCRIPTION
https://mail.python.org/pipermail/distutils-sig/2017-October/031642.html 
Since pip 10+ removed internal APIs, pip.req is no longer available, and I just moved whatever is in requirements.txt directly into the setup script